### PR TITLE
Listen for subscriptions being "paused" instead of canceled (same han…

### DIFF
--- a/webapp/src/components/SubscriptionCard.tsx
+++ b/webapp/src/components/SubscriptionCard.tsx
@@ -110,11 +110,13 @@ export default function SubscriptionCard({ title, link = null, plan = null, pric
 				{stripeTrial && <span className='px-2 py-[0.5px] me-2 bg-white text-orange-800 border border-orange-800 text-sm rounded-lg'>
 						Trial
 				</span>}
-				{price > 0 && (
+				{price > 0 ? (
 					<span suppressHydrationWarning className={`text-sm px-2 py-[0.5px] me-2 bg-white text-${stripeCancelled ? 'orange-700' : 'green-800'} border border-${stripeCancelled ? 'orange-800' : 'green-800'} text-sm rounded-lg`}>
 						{stripeCancelled === true ? 'Ends' : 'Renews'} {new Date(stripeEndsAt).toDateString()}
 					</span>
-				)}
+				 	) : <span className='px-2 py-[0.5px] me-2 bg-white text-blue-800 border border-blue-800 text-sm rounded-lg'>
+						Current Plan
+				</span>}
 			</div>)}
 			<div className='flex justify-center align-middle mt-4'>
 				<img className='rounded-md w-24 h-24 lg:w-48 lg:h-48' src={`/images/agentcloud-mark-white-bg-black-${plan}.png`} />

--- a/webapp/src/lib/account/create.ts
+++ b/webapp/src/lib/account/create.ts
@@ -159,7 +159,7 @@ export default async function createAccount(
 				trial_period_days: 14,
 				trial_settings: {
 					end_behavior: {
-						missing_payment_method: 'cancel',
+						missing_payment_method: 'pause',
 					}
 				}
 			});


### PR DESCRIPTION
…dler)

Change subscriptions to pause instead of cancel on ending with no payment method Show "current plan" on free plan instead of an ends/renewal date Add a listener for subscription created to set stipe props on new subscriptions after resubscribing Improve logic in stripe subscription add/update webhook handler close #281