### PR TITLE
Update the sync-successful webhook to handle 0 row datasources correc…

### DIFF
--- a/webapp/src/controllers/airbyte.ts
+++ b/webapp/src/controllers/airbyte.ts
@@ -237,6 +237,7 @@ export async function handleSuccessfulSyncWebhook(req, res, next) {
 	const { jobId, datasourceId, recordsLoaded } = extractWebhookSuccesfulDetails(
 		req.body?.blocks || []
 	);
+	const noDataToSync = recordsLoaded === 0;
 	if (jobId && datasourceId) {
 		const datasource = await unsafeGetDatasourceById(datasourceId);
 		if (datasource) {
@@ -259,7 +260,7 @@ export async function handleSuccessfulSyncWebhook(req, res, next) {
 				seen: false,
 				// stuff specific to notification type
 				description:
-					datasource?.sourceType === 'file'
+					datasource?.sourceType === 'file' || noDataToSync
 						? `Your sync for datasource "${datasource.name}" has completed.`
 						: `Embedding is in progress for datasource "${datasource.name}".`,
 				type: NotificationType.Webhook,
@@ -270,7 +271,11 @@ export async function handleSuccessfulSyncWebhook(req, res, next) {
 			await Promise.all([
 				addNotification(notification),
 				setDatasourceLastSynced(datasource.teamId, datasourceId, new Date()),
-				setDatasourceStatus(datasource.teamId, datasourceId, DatasourceStatus.EMBEDDING),
+				setDatasourceStatus(
+					datasource.teamId,
+					datasourceId,
+					noDataToSync ? DatasourceStatus.READY : DatasourceStatus.EMBEDDING
+				),
 				setDatasourceTotalRecordCount(datasource.teamId, datasourceId, recordsLoaded)
 			]);
 			io.to(datasource.teamId.toString()).emit('notification', notification);


### PR DESCRIPTION
…tly. Send the correct notification and already be marked ready instead of being stuck processing because vecotr-proxy won't get any rows and thus webapp never gets the second webhook.