### PR TITLE
Draft: fix structured input for public sessions

### DIFF
--- a/webapp/src/api.ts
+++ b/webapp/src/api.ts
@@ -306,7 +306,7 @@ export function deleteKey(body, dispatch, errorCallback, router) {
 export function getTasks(body, dispatch, errorCallback, router) {
 	return ApiCall(`/${body.resourceSlug}/tasks.json`, 'GET', null, dispatch, errorCallback, router);
 }
-export function getTask(body, dispatch, errorCallback, router) {
+export function getTaskById(body, dispatch, errorCallback, router) {
 	return ApiCall(
 		`/${body.resourceSlug}/task/${body.taskId}.json`,
 		'GET',
@@ -316,11 +316,15 @@ export function getTask(body, dispatch, errorCallback, router) {
 		router
 	);
 }
-export function getTaskByName(body, dispatch: GetTaskByNameDispatch, errorCallback, router) {
+export function getTask(body, dispatch: GetTaskByNameDispatch, errorCallback, router) {
+	const queryString = new URLSearchParams({
+		...(body.name ? { name: body.name } : {}),
+		...(body.sessionId ? { sessionId: body.sessionId } : {}), //could go in params but whatever
+	});
 	return ApiCall(
-		`/${body.resourceSlug}/task/get-by-name`,
-		'POST',
-		body,
+		`/${body.resourceSlug}/task?${queryString}`,
+		'GET',
+		null,
 		dispatch,
 		errorCallback,
 		router

--- a/webapp/src/components/session/StructuredInputForm.tsx
+++ b/webapp/src/components/session/StructuredInputForm.tsx
@@ -39,11 +39,10 @@ const StructuredInputForm = ({ formFields, sendMessage }: HumanInputFormProps) =
 					case 'number':
 					case 'date':
 						return (
-							<>
+							<React.Fragment key={field.name}>
 								<div className='invisible xl:visible col-span-1'></div>
 
 								<div
-									key={field.name}
 									className={cn(
 										index === 0 && 'rounded-t-lg',
 										'flex flex-col ps-2 justify-start px-4 pt-1 col-span-1 xl:col-span-3'
@@ -69,14 +68,13 @@ const StructuredInputForm = ({ formFields, sendMessage }: HumanInputFormProps) =
 									)}
 								</div>
 								<div className='invisible xl:visible col-span-1'></div>
-							</>
+							</React.Fragment>
 						);
 					case 'radio':
 						return (
-							<>
+							<React.Fragment key={field.name}>
 								<div className='invisible xl:visible col-span-1'></div>
 								<div
-									key={field.name}
 									className={cn(
 										index === 0 && 'rounded-t-lg',
 										'flex flex-col ps-2 justify-start px-4 pt-1 col-span-1 xl:col-span-3'
@@ -114,14 +112,13 @@ const StructuredInputForm = ({ formFields, sendMessage }: HumanInputFormProps) =
 									)}
 								</div>
 								<div className='invisible xl:visible col-span-1'></div>
-							</>
+							</React.Fragment>
 						);
 					case 'checkbox':
 						return (
-							<>
+							<React.Fragment key={field.name}>
 								<div className='invisible xl:visible col-span-1'></div>
 								<div
-									key={field.name}
 									className={cn(
 										index === 0 && 'rounded-t-lg',
 										'flex flex-col ps-2 justify-start px-4 pt-1 col-span-1 xl:col-span-3 my-2'
@@ -168,16 +165,15 @@ const StructuredInputForm = ({ formFields, sendMessage }: HumanInputFormProps) =
 									)}
 								</div>
 								<div className='invisible xl:visible col-span-1'></div>
-							</>
+							</React.Fragment>
 						);
 					case 'select':
 					case 'multiselect':
 						return (
-							<>
+							<React.Fragment key={field.name}>
 								<div className='invisible xl:visible col-span-1'></div>
 
 								<div
-									key={field.name}
 									className={cn(
 										index === 0 && 'rounded-t-lg',
 										'flex flex-col ps-2 justify-start px-4 pt-1 col-span-1 xl:col-span-3 my-2'
@@ -207,7 +203,7 @@ const StructuredInputForm = ({ formFields, sendMessage }: HumanInputFormProps) =
 									)}
 								</div>
 								<div className='invisible xl:visible col-span-1'></div>
-							</>
+							</React.Fragment>
 						);
 					default:
 						return null;

--- a/webapp/src/hooks/session/useActiveTask.ts
+++ b/webapp/src/hooks/session/useActiveTask.ts
@@ -16,7 +16,7 @@ const useActiveTask = (messages: any[]) => {
 	);
 	const router = useRouter();
 
-	const { resourceSlug } = router.query;
+	const { resourceSlug, sessionId } = router.query;
 
 	useEffect(() => {
 		if (lastRunningTaskName) {
@@ -25,10 +25,11 @@ const useActiveTask = (messages: any[]) => {
 			);
 			const taskName = taskNameMatch ? taskNameMatch[1].trim() : null;
 
-			API.getTaskByName(
+			API.getTask(
 				{
 					resourceSlug,
-					taskName,
+					sessionId,
+					name: taskName,
 					_csrf: csrf
 				},
 				setActiveTask,

--- a/webapp/src/pages/[resourceSlug]/task/[taskId]/edit.tsx
+++ b/webapp/src/pages/[resourceSlug]/task/[taskId]/edit.tsx
@@ -19,7 +19,7 @@ export default function EditTask(props) {
 	const taskChoices = tasks?.filter(x => x._id.toString() !== task._id.toString()) || [];
 
 	async function fetchTaskFormData() {
-		await API.getTask(
+		await API.getTaskById(
 			{
 				resourceSlug,
 				taskId

--- a/webapp/src/pages/[resourceSlug]/task/add.tsx
+++ b/webapp/src/pages/[resourceSlug]/task/add.tsx
@@ -22,7 +22,7 @@ export default function AddTask(props) {
 	}
 
 	async function fetchEditData(taskId) {
-		await API.getTask({ resourceSlug, taskId }, setCloneState, setError, router);
+		await API.getTaskById({ resourceSlug, taskId }, setCloneState, setError, router);
 	}
 
 	useEffect(() => {

--- a/webapp/src/router.ts
+++ b/webapp/src/router.ts
@@ -294,6 +294,10 @@ export default function router(server, app) {
 		'/:shareLinkShareId(app_[a-f0-9]{64,})', //Note: app_prefix to be removed once we handle other sharinglinktypes
 		sharelinkController.handleRedirect
 	);
+	publicAppRouter.get(
+		'/task',
+		taskController.publicGetTaskJson
+	);
 	server.use('/s/:resourceSlug([a-f0-9]{24})', unauthedMiddlewareChain, publicAppRouter);
 
 	// Airbyte webhooks
@@ -366,10 +370,10 @@ export default function router(server, app) {
 		hasPerms.one(Permissions.CREATE_TASK),
 		taskController.taskAddPage.bind(null, app)
 	);
-	teamRouter.get('/task/:taskId([a-f0-9]{24}).json', taskController.taskJson);
-	teamRouter.post(
-		'/task/get-by-name',
-		taskController.taskByName
+	teamRouter.get('/task/:taskId([a-f0-9]{24}).json', taskController.getTaskByIdJson);
+	teamRouter.get(
+		'/task',
+		taskController.getTaskJson
 	);
 	teamRouter.get(
 		'/task/:taskId([a-f0-9]{24})/edit',


### PR DESCRIPTION
Add the ability to fetch a task by name in public sessions, so that structured input works for public sessions
Change fetching task by name to be a generic function that we can add different filters to later, and the original getTask to be getTaskById Change getTask methods to actually be a GET, instead of a POST. update useActivetask and other frontend components to use the updated getTask and getTaskById