### PR TITLE
Enhance Minio setup and configuration in storage module

### DIFF
--- a/agent-backend/src/storage/__init__.py
+++ b/agent-backend/src/storage/__init__.py
@@ -1,11 +1,14 @@
-from .google import google_storage_provider
-from .local import local_storage_provider
 import os
 
-STORAGE_PROVIDER = os.getenv('STORAGE_PROVIDER', 'local')
+STORAGE_PROVIDER = os.getenv("STORAGE_PROVIDER", "local")
+print(f"STORAGE_PROVIDER: {STORAGE_PROVIDER}")
 
-if STORAGE_PROVIDER == 'google':
+
+if STORAGE_PROVIDER == "google":
+    from .google import google_storage_provider
+
     storage_provider = google_storage_provider
 else:
-    storage_provider = local_storage_provider
+    from .local import local_storage_provider
 
+    storage_provider = local_storage_provider

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -179,7 +179,11 @@ services:
       - UPLOADS_BASE_PATH=/tmp
       - GOOGLE_APPLICATION_CREDENTIALS=keyfile.json
       - PROJECT_ID=agentcloud-dev
-      - STORAGE_PROVIDER=google
+      - STORAGE_PROVIDER=local
+      - MINIO_INTERNAL_ENDPOINT=minio:9000  
+      - MINIO_EXTERNAL_ENDPOINT=localhost:9000 
+      - MINIO_ROOT_USER=minioadmin
+      - MINIO_ROOT_PASSWORD=minioadmin
 
   vector_db_proxy:
     restart: always


### PR DESCRIPTION
  - Conditional import of storage providers based on the `STORAGE_PROVIDER` environment variable.
  - Updated Minio configuration to use internal and external endpoints.
  - Added method to set public read policy for Minio buckets.
  - Modified `get_signed_url` to generate a public URL instead of a signed URL.
  - Added Minio-related environment variables to `docker-compose.yml`.