### PR TITLE
Change sharelink redirects to actually start session in agent-backend

### DIFF
--- a/webapp/src/pages/[resourceSlug]/session/[sessionId]/index.tsx
+++ b/webapp/src/pages/[resourceSlug]/session/[sessionId]/index.tsx
@@ -29,6 +29,8 @@ export default function Session(props) {
 	const path = usePathname();
 	const isShared = path.startsWith('/s/');
 	const hasAppSegment = path.includes('/app');
+	console.log('isShared', isShared);
+	console.log('hasAppSegment', hasAppSegment);
 	const [lastSeenMessageId, setLastSeenMessageId] = useState(null);
 	const [error, setError] = useState();
 	// @ts-ignore
@@ -274,19 +276,6 @@ export default function Session(props) {
 		if (!message || message.trim().length === 0) {
 			return null;
 		}
-		if (isShared && showConversationStarters) {
-			const res = await API.publicStartApp(
-				{
-					resourceSlug: app?.teamId,
-					id: app?._id
-				},
-				null,
-				toast.error,
-				null
-			);
-			res.redirect && router.push(`/s${res.redirect}`, null, { shallow: true });
-			return;
-		}
 		socketContext.emit('message', {
 			room: sessionId,
 			authorName: account?.name,
@@ -298,12 +287,6 @@ export default function Session(props) {
 		reset && reset();
 		return true;
 	}
-
-	useEffect(() => {
-		if (hasAppSegment && isShared) {
-			sendMessage('!', null);
-		}
-	}, [hasAppSegment, isShared]);
 
 	return (
 		<>

--- a/webapp/src/pages/[resourceSlug]/session/[sessionId]/index.tsx
+++ b/webapp/src/pages/[resourceSlug]/session/[sessionId]/index.tsx
@@ -29,8 +29,6 @@ export default function Session(props) {
 	const path = usePathname();
 	const isShared = path.startsWith('/s/');
 	const hasAppSegment = path.includes('/app');
-	console.log('isShared', isShared);
-	console.log('hasAppSegment', hasAppSegment);
 	const [lastSeenMessageId, setLastSeenMessageId] = useState(null);
 	const [error, setError] = useState();
 	// @ts-ignore

--- a/webapp/src/router.ts
+++ b/webapp/src/router.ts
@@ -254,7 +254,7 @@ export default function router(server, app) {
 	);
 
 	
-	//ApiKey Endpoints
+	// api key endpoints
 	accountRouter.post('/apikey/add',authedMiddlewareChain ,apiKeyController.addKeyApi);
 	accountRouter.delete('/apikey/:keyId([a-f0-9]{24})', authedMiddlewareChain, apiKeyController.deleteKeyApi);
 	accountRouter.post('/apikey/:keyId([a-f0-9]{24})/increment', authedMiddlewareChain, apiKeyController.incrementKeyApi);
@@ -265,15 +265,8 @@ export default function router(server, app) {
 	server.get('/apikeys',authedMiddlewareChain ,apiKeyController.apiKeysPage.bind(null, app));
 	server.get('/apikeys.json',authedMiddlewareChain ,apiKeyController.apikeysJson);
 
-
-
+	// public session endpoints
 	const publicAppRouter = Router({ mergeParams: true, caseSensitive: true });
-	publicAppRouter.get(
-		'/app/:appId([a-f0-9]{24})',
-		csrfMiddleware,
-		setParamOrgAndTeam,
-		sessionController.publicSessionPage.bind(null, app)
-	);
 	publicAppRouter.get(
 		'/session/:sessionId([a-f0-9]{24})',
 		csrfMiddleware,


### PR DESCRIPTION
Remove frontend handling of session initiation which created a duplicate session and left the previous session unused Remove the need for the /app/ special public session page

I think this will sort out your issue @charl3sj :slightly_smiling_face: 