### PR TITLE
Allow `requiresHumanInput` field to be null in task API

### DIFF
--- a/webapp/src/controllers/task.ts
+++ b/webapp/src/controllers/task.ts
@@ -132,7 +132,7 @@ export async function addTaskApi(req, res, next) {
 		[
 			{ field: 'name', validation: { notEmpty: true, ofType: 'string' } },
 			{ field: 'description', validation: { notEmpty: true, ofType: 'string' } },
-			{ field: 'requiresHumanInput', validation: { notEmpty: true, ofType: 'boolean' } },
+			{ field: 'requiresHumanInput', validation: { ofType: 'boolean' } },
 			{ field: 'expectedOutput', validation: { ofType: 'string' } },
 			{
 				field: 'toolIds',


### PR DESCRIPTION
fixes #546 
  - Removed the `notEmpty` validation for the `requiresHumanInput` field in the `addTaskApi` function.