### PR TITLE
  Make 'Expected Output' a mandatory field in TaskForm and API

### DIFF
--- a/webapp/src/components/TaskForm.tsx
+++ b/webapp/src/components/TaskForm.tsx
@@ -358,7 +358,7 @@ export default function TaskForm({
 									htmlFor='expectedOutput'
 									className='block text-sm font-medium leading-6 text-gray-900 dark:text-slate-400'
 								>
-									Expected Output
+									Expected Output<span className='text-red-700'> *</span>
 								</label>
 
 								<div className='ml-auto text-gray-900 dark:text-gray-50 text-sm mr-2'>

--- a/webapp/src/controllers/task.ts
+++ b/webapp/src/controllers/task.ts
@@ -133,7 +133,7 @@ export async function addTaskApi(req, res, next) {
 			{ field: 'name', validation: { notEmpty: true, ofType: 'string' } },
 			{ field: 'description', validation: { notEmpty: true, ofType: 'string' } },
 			{ field: 'requiresHumanInput', validation: { notEmpty: true, ofType: 'boolean' } },
-			{ field: 'expectedOutput', validation: { ofType: 'string' } },
+			{ field: 'expectedOutput', validation: { notEmpty: true, ofType: 'string' } },
 			{
 				field: 'toolIds',
 				validation: {


### PR DESCRIPTION
fixes #543 
  - Added a red asterisk to the 'Expected Output' label in the TaskForm component to indicate it is mandatory.
  - Updated the task API controller to enforce 'expectedOutput' as a required field.