### PR TITLE
Add migration script to update team member permissions #606

### DIFF
--- a/webapp/src/lib/permissions/roles.ts
+++ b/webapp/src/lib/permissions/roles.ts
@@ -27,7 +27,7 @@ TEAM_OWNER.setAll(ORG_BITS);
 const TEAM_ADMIN = new Permission();
 TEAM_ADMIN.setAll(TEAM_BITS);
 
-const TEAM_MEMBER = new Permission();
+export const TEAM_MEMBER = new Permission();
 TEAM_MEMBER.setAll([
 	Permissions.CREATE_APP,
 	Permissions.EDIT_APP,

--- a/webapp/src/migrations/1.12.0.ts
+++ b/webapp/src/migrations/1.12.0.ts
@@ -1,0 +1,35 @@
+import Permission from '@permission';
+import debug from 'debug';
+import { Binary } from 'mongodb';
+import { TEAM_MEMBER } from 'permissions/roles';
+
+const log = debug('webapp:migration:1.10.0');
+
+async function updateTeamMemberPermissions(db) {
+	const teamMemberPermissions = new Permission();
+	teamMemberPermissions.setAll(TEAM_MEMBER.array);
+	const accounts = await db.collection('accounts').find().toArray();
+	for (const account of accounts) {
+		const accountPermissions = new Permission(account.permissions.buffer);
+		const isTeamMember = TEAM_MEMBER.array.some(bit => accountPermissions.get(bit));
+		if (!isTeamMember) {
+			continue;
+		}
+		const hasAllTeamMemberPermissions = TEAM_MEMBER.array.every(bit => accountPermissions.get(bit));
+		if (!hasAllTeamMemberPermissions) {
+			accountPermissions.setAll(teamMemberPermissions.array);
+			await db
+				.collection('accounts')
+				.updateOne(
+					{ _id: account._id },
+					{ $set: { permissions: new Binary(accountPermissions.array) } }
+				);
+		}
+	}
+}
+
+export default async function (db) {
+	log('Starting migration to update TEAM_MEMBER permissions');
+	await updateTeamMemberPermissions(db);
+	log('Migration to update TEAM_MEMBER permissions completed');
+}


### PR DESCRIPTION
- Added a migration script to update all team member accounts to have variable permissions.
- Exported the TEAM_MEMBER constant to allow its use in the migration script.
- Implemented logic to ensure all team members have the correct permissions set.