### PR TITLE
  Implement Singleton Pattern and Limit MongoDB Connection Pool Size

### DIFF
--- a/agent-backend/src/crew/build_crew.py
+++ b/agent-backend/src/crew/build_crew.py
@@ -360,3 +360,4 @@ class CrewAIBuilder:
             event=SocketEvents.STOP_GENERATING,
             chunk_id=str(uuid.uuid4()),
         )
+        mongo_client.disconnect()

--- a/agent-backend/src/mongo/client.py
+++ b/agent-backend/src/mongo/client.py
@@ -10,7 +10,7 @@ class MongoConnection:
 
     def connect(self) -> Optional[MongoClient]:
         try:
-            mongo_client = MongoClient(self.mongo_uri)
+            mongo_client = MongoClient(self.mongo_uri, maxPoolSize=10)
             return mongo_client
         except Exception as e:
             logging.exception(e)

--- a/agent-backend/src/mongo/queries.py
+++ b/agent-backend/src/mongo/queries.py
@@ -12,10 +12,24 @@ from utils.model_helper import convert_dictionaries_to_models, get_models_attrib
 
 
 class MongoClientConnection(MongoConnection):
+    _instance = None  
+
+    def __new__(cls, *args, **kwargs):
+        if not cls._instance:
+            cls._instance = super(MongoClientConnection, cls).__new__(cls)
+        return cls._instance
+
     def __init__(self):
-        super().__init__()
-        self.mongo_client = self.connect()
-        self.db = self.mongo_client[MONGO_DB_NAME]
+        if not hasattr(self, 'initialized'):  
+            super().__init__()
+            self.mongo_client = self.connect()
+            self.db = self.mongo_client[MONGO_DB_NAME]
+            self.initialized = True   
+
+    def disconnect(self):
+        print("Disconnecting from MongoDB")
+        self.mongo_client.close()        
+        self.initialized = None  # Reset initialized status
 
     def _get_collection(self, collection_name: str) -> collection.Collection:
         return self.db[collection_name]

--- a/webapp/src/db/index.ts
+++ b/webapp/src/db/index.ts
@@ -7,12 +7,18 @@ import { InsertResult } from 'struct/db';
 
 export type IdOrStr = string | ObjectId;
 
-let _client;
+let _client: MongoClient | null = null;
 
 export async function connect() {
-	_client = new MongoClient(process.env.DB_URL);
-	log('connecting to mongodb');
-	await _client.connect();
+	if (!_client) {
+		_client = new MongoClient(process.env.DB_URL, {
+			maxPoolSize: 10
+		});
+		log('connecting to mongodb');
+		await _client.connect();
+	} else {
+		log('mongodb connection already established');
+	}
 }
 
 export function client(): MongoClient {


### PR DESCRIPTION
  - Implemented the singleton pattern for MongoDB connections to ensure a single instance is used across the application.
  - Limited the MongoDB connection pool size to 10 to optimize resource usage.
  - Added a disconnect method to properly close MongoDB connections when they are no longer needed.
