### PR TITLE
 Enhance Pinecone Index Creation with Cloud and Region Configuration

### DIFF
--- a/vector-db-proxy/src/adaptors/mongo/models.rs
+++ b/vector-db-proxy/src/adaptors/mongo/models.rs
@@ -127,6 +127,8 @@ pub struct DataSources {
     pub vector_db_id: Option<ObjectId>,
     #[serde(flatten)]
     pub extra_fields: bson::Document,
+    pub region: Option<String>,
+    pub cloud: Option<String>,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug)]

--- a/vector-db-proxy/src/adaptors/pinecone/apis.rs
+++ b/vector-db-proxy/src/adaptors/pinecone/apis.rs
@@ -116,7 +116,7 @@ impl VectorDatabase for PineconeClient {
         &self,
         search_request: SearchRequest,
     ) -> Result<VectorDatabaseStatus, VectorDatabaseError> {
-        let region = search_request.clone().region.unwrap_or(Region::US);
+        let region = search_request.clone().region.unwrap_or(Region::US_EAST_1);
         let index_name = search_request
             .byo_vector_db
             .map_or(Region::to_str(region), |_k| {
@@ -140,7 +140,7 @@ impl VectorDatabase for PineconeClient {
         search_request: SearchRequest,
         point: Point,
     ) -> Result<VectorDatabaseStatus, VectorDatabaseError> {
-        let region = search_request.clone().region.unwrap_or(Region::US);
+        let region = search_request.clone().region.unwrap_or(Region::US_EAST_1);
         let vector = Vector::from(point);
         let namespace = search_request
             .clone()
@@ -193,7 +193,7 @@ impl VectorDatabase for PineconeClient {
         &self,
         search_request: SearchRequest,
     ) -> Result<VectorDatabaseStatus, VectorDatabaseError> {
-        let region = search_request.region.unwrap_or(Region::US);
+        let region = search_request.region.unwrap_or(Region::US_EAST_1);
         let pinecone_filters = search_request
             .clone()
             .filters
@@ -233,7 +233,7 @@ impl VectorDatabase for PineconeClient {
         search_request: SearchRequest,
         points: Vec<Point>,
     ) -> Result<VectorDatabaseStatus, VectorDatabaseError> {
-        let region = search_request.clone().region.unwrap_or(Region::US);
+        let region = search_request.clone().region.unwrap_or(Region::US_EAST_1);
         let vectors: Vec<Vector> = points.iter().map(|p| Vector::from(p.to_owned())).collect();
         let namespace = search_request
             .clone()
@@ -318,7 +318,7 @@ impl VectorDatabase for PineconeClient {
         &self,
         search_request: SearchRequest,
     ) -> Result<Option<CollectionMetadata>, VectorDatabaseError> {
-        let region = search_request.clone().region.unwrap_or(Region::US);
+        let region = search_request.clone().region.unwrap_or(Region::US_EAST_1);
         if let Ok(index_model) = get_index_model(&self, Region::to_str(region).to_string()).await {
             let mut index = self.index(index_model.host.as_str()).await.unwrap();
             let index_stats = index.describe_index_stats(None).await.unwrap();
@@ -365,7 +365,7 @@ impl VectorDatabase for PineconeClient {
         &self,
         search_request: SearchRequest,
     ) -> Result<Vec<SearchResult>, VectorDatabaseError> {
-        let region = search_request.clone().region.unwrap_or(Region::US);
+        let region = search_request.clone().region.unwrap_or(Region::US_EAST_1);
         if let Ok(index_model) = get_index_model(&self, Region::to_str(region).to_string()).await {
             let mut index = self.index(index_model.host.as_str()).await.unwrap();
             let namespace = Namespace::from(search_request.collection.as_str());

--- a/vector-db-proxy/src/routes/apis.rs
+++ b/vector-db-proxy/src/routes/apis.rs
@@ -249,7 +249,6 @@ pub async fn create_collection(
 ) -> Result<HttpResponse> {
     let collection_id = data.clone().collection_name;
     let mongodb_connection = start_mongo_connection().await?;
-    let mut collection_create = data.clone();
     match get_datasource(&mongodb_connection, collection_id.as_str()).await {
         Ok(option) => match option {
             Some(datasource) => {
@@ -258,10 +257,6 @@ pub async fn create_collection(
                         .await
                         .unwrap_or(default_vector_db_client().await);
                 let vector_database_client = vector_database_client.read().await;
-                collection_create.collection_name = datasource
-                    .collection_name
-                    .map_or(collection_id.clone(), |d| d);
-                collection_create.namespace = datasource.namespace;
                 match vector_database_client.create_collection(data.clone()).await {
                     Ok(collection_result) => match collection_result {
                         VectorDatabaseStatus::Ok => Ok(HttpResponse::Ok()

--- a/vector-db-proxy/src/vector_databases/models.rs
+++ b/vector-db-proxy/src/vector_databases/models.rs
@@ -204,35 +204,48 @@ impl SearchRequest {
             top_k: None,
             byo_vector_db: None,
             search_response_params: None,
-            region: Some(Region::US),
-            cloud: Some(Cloud::GCP),
+            region: Some(Region::US_EAST_1),
+            cloud: Some(Cloud::AWS),
         }
     }
 }
+
 #[derive(Serialize, Deserialize, Clone, Debug, Copy)]
 pub enum Region {
-    US,
-    EU,
+    US_EAST_1,
+    US_WEST_2,
+    EU_WEST_1,
+    US_CENTRAL_1,
+    EU_WEST_4,
+    EAST_US_2,
 }
+
 impl Default for Region {
     fn default() -> Self {
-        Self::US
+        Self::US_EAST_1
     }
 }
 
 impl Region {
     pub fn to_str<'a>(region: Self) -> &'a str {
         match region {
-            Self::US => "us-central1",
-            Self::EU => "europe-west4",
+            Self::US_EAST_1 => "us-east-1",
+            Self::US_WEST_2 => "us-west-2",
+            Self::EU_WEST_1 => "eu-west-1",
+            Self::US_CENTRAL_1 => "us-central1",
+            Self::EU_WEST_4 => "europe-west4",
+            Self::EAST_US_2 => "eastus2",
         }
     }
-
     pub fn from_str(region: &str) -> Self {
         match region {
-            "us-central1" => Region::US,
-            "europe-west4" => Region::EU,
-            _ => panic!("Unknown Pinecone serverless region"),
+            "us-east-1" => Region::US_EAST_1,
+            "us-west-2" => Region::US_WEST_2,
+            "eu-west-1" => Region::EU_WEST_1,
+            "us-central1" => Region::US_CENTRAL_1,
+            "europe-west4" => Region::EU_WEST_4,
+            "eastus2" => Region::EAST_US_2,
+            _ => panic!("Unknown Pinecone serverless region: {}", region),
         }
     }
 }
@@ -350,15 +363,18 @@ pub struct CollectionCreate {
     pub namespace: Option<String>,
     pub distance: Distance,
     pub vector_name: Option<String>,
-    pub region: Option<Region>,
-    pub cloud: Option<Cloud>,
+    pub region: Option<String>,
+    pub cloud: Option<String>,
+    pub index_name: Option<String>,
 }
 impl CollectionCreate {
     pub fn new(
         collection_name: String,
         dimensions: usize,
         distance: Distance,
-        region: Region,
+        region: String,
+        cloud: String,
+        index_name: String,
     ) -> Self {
         Self {
             collection_name: collection_name.clone(),
@@ -366,8 +382,9 @@ impl CollectionCreate {
             distance,
             namespace: None,
             vector_name: None,
-            cloud: Some(Cloud::AWS),
+            cloud: Some(cloud),
             region: Some(region),
+            index_name: Some(index_name),
         }
     }
 }

--- a/webapp/src/controllers/datasource.ts
+++ b/webapp/src/controllers/datasource.ts
@@ -345,7 +345,9 @@ export async function addDatasourceApi(req, res, next) {
 		vectorDbId,
 		byoVectorDb,
 		collectionName,
-		noRedirect
+		noRedirect,
+		region,
+		cloud
 	} = req.body;
 
 	const currentPlan = res.locals?.subscription?.stripePlan;
@@ -475,11 +477,18 @@ export async function addDatasourceApi(req, res, next) {
 		vectorDbId: toObjectId(vectorDbId),
 		byoVectorDb,
 		collectionName: collectionName ?? datasourceId,
-		namespace: datasourceId
+		namespace: datasourceId,
+		region,
+		cloud
 	});
 
 	try {
-		await VectorDBProxyClient.createCollection(datasourceId);
+		await VectorDBProxyClient.createCollection(datasourceId, {
+			cloud,
+			region,
+			collection_name: collectionName,
+			index_name: collectionName
+		});
 	} catch (e) {
 		console.error(e);
 		return dynamicResponse(req, res, 400, {

--- a/webapp/src/lib/struct/datasource.ts
+++ b/webapp/src/lib/struct/datasource.ts
@@ -1,7 +1,8 @@
 'use strict';
 
-import { ObjectId } from 'mongodb';
-import { InferSchemaType, Model, model, models, mongo, Mongoose, Schema, Types } from 'mongoose';
+import { InferSchemaType, model, models, Schema, Types } from 'mongoose';
+
+import { Cloud, Region } from './vectorproxy';
 const MongooseObjectId = Types.ObjectId;
 
 export type DatasourceStream = {
@@ -156,6 +157,8 @@ export interface Datasource {
 	collectionName?: string;
 	namespace?: string;
 	byoVectorDb?: boolean;
+	region?: Region;
+	cloud?: Cloud;
 }
 
 const datasourceSchema = new Schema<Datasource>(
@@ -186,7 +189,9 @@ const datasourceSchema = new Schema<Datasource>(
 		timeUnit: String,
 		collectionName: String,
 		namespace: String,
-		byoVectorDb: Boolean
+		byoVectorDb: Boolean,
+		region: String,
+		cloud: String
 	},
 	{ timestamps: true }
 );

--- a/webapp/src/lib/struct/vectorproxy.ts
+++ b/webapp/src/lib/struct/vectorproxy.ts
@@ -26,10 +26,19 @@ export enum Distance { // Note: always cosine (for now)
 }
 
 export enum Region {
-	US = 'US',
-	EU = 'EU',
-	AU = 'AU'
+	US_EAST_1 = 'us-east-1', // Virginia
+	US_WEST_2 = 'us-west-2', // Oregon
+	EU_WEST_1 = 'eu-west-1', // Ireland
+	US_CENTRAL_1 = 'us-central1', // Iowa
+	EU_WEST_4 = 'europe-west4', // Netherlands
+	EASTUS2 = 'eastus2' // Virginia
 }
+
+export const CloudRegionMap: Record<Cloud, Region[]> = {
+	[Cloud.AWS]: [Region.US_EAST_1, Region.US_WEST_2, Region.EU_WEST_1],
+	[Cloud.GCP]: [Region.US_CENTRAL_1, Region.EU_WEST_4],
+	[Cloud.AZURE]: [Region.EASTUS2]
+};
 
 export interface CollectionCreateBody {
 	collection_name: string;

--- a/webapp/src/lib/struct/vectorproxy.ts
+++ b/webapp/src/lib/struct/vectorproxy.ts
@@ -41,9 +41,11 @@ export const CloudRegionMap: Record<Cloud, Region[]> = {
 };
 
 export interface CollectionCreateBody {
-	collection_name: string;
+	collection_name?: string;
 	dimensions?: number;
 	distance?: Distance; // cosine always for now
 	vector_name?: string; // vector_name is just a Model.config.model e.g. "text-embedding-3-small"
 	region?: Region; // Made region optional here
+	cloud?: Cloud;
+	index_name?: string;
 }


### PR DESCRIPTION
  - Added support for specifying cloud provider and region when creating Pinecone vector databases in the datasource form.
  - Updated backend API to handle `cloud` and `region` parameters for datasource creation and vector database interactions.
  - Enhanced the `Region` enum and related logic to support specific region codes and cloud-region mappings.
  - Modified the Pinecone client and API routes to utilize the new `cloud` and `region` parameters 