### PR TITLE
  Fix link path in VectorDbs page to correct endpoint

### DIFF
--- a/webapp/src/pages/[resourceSlug]/vectordbs.tsx
+++ b/webapp/src/pages/[resourceSlug]/vectordbs.tsx
@@ -48,7 +48,7 @@ export default function VectorDbs(props) {
 
 			{vectorDbs.length === 0 && (
 				<NewButtonSection
-					link={`/${resourceSlug}/variable/add`}
+					link={`/${resourceSlug}/vectordb/add`}
 					emptyMessage={'No vector databases'}
 					message={'Get started by vector databases.'}
 					buttonIcon={<PlusIcon className='-ml-0.5 mr-1.5 h-5 w-5' aria-hidden='true' />}


### PR DESCRIPTION
  - Fixed the link path in the `NewButtonSection` component to correctly point to `vectordb/add` instead of `variable/add`.