### PR TITLE
Resolve logger warnings

### DIFF
--- a/agent-backend/src/crew/build_crew.py
+++ b/agent-backend/src/crew/build_crew.py
@@ -120,7 +120,7 @@ class CrewAIBuilder:
                         if linked_tool:
                             tool_name = linked_tool.data.name
                         else:
-                            logging.warn(f"linked tool ID {tool.linkedToolId} not found for installed tool {tool.id}")
+                            logging.warning(f"linked tool ID {tool.linkedToolId} not found for installed tool {tool.id}")
                     tool_class = BuiltinTools.get_tool_class(tool_name)
             # Assign tool models and datasources
             datasources = search_subordinate_keys(self.datasources_models, key)

--- a/agent-backend/src/storage/google.py
+++ b/agent-backend/src/storage/google.py
@@ -22,7 +22,7 @@ class GoogleStorageProvider(StorageProvider):
             # Initialize the storage client with the credentials
             self.storage_client = storage.Client(credentials=credentials, project=PROJECT_ID)
         else:
-            logging.warn('GOOGLE_APPLICATION_CREDENTIALS_JSON environment variable is not set.')
+            logging.warning('GOOGLE_APPLICATION_CREDENTIALS_JSON environment variable is not set.')
             self.storage_client = storage.Client(project=PROJECT_ID)
 
     async def init(self):


### PR DESCRIPTION
## PR Summary
This small PR resolves the annoying deprecation warnings of the `logger` library:
```python
DeprecationWarning: The 'warn' method is deprecated, use 'warning' instead
```